### PR TITLE
[west.yaml] Use full fatfs revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -56,7 +56,7 @@ manifest:
 
     - name: fatfs
       remote: zephyrproject-rtos
-      revision: 427159b
+      revision: "427159bf95ea49b7680facffaa29ad506b42709b"
       path: modules/fs/fatfs
       groups:
         - fs


### PR DESCRIPTION
moulin can't properly fetch this module with short revision. Use full revision to fix the issue.