### PR TITLE
[smclient] Rename error_info field to error in instance status

### DIFF
--- a/src/smclient/smclient.cpp
+++ b/src/smclient/smclient.cpp
@@ -71,8 +71,8 @@ void InstanceStatusToPB(const InstanceStatus& aosInstanceStatus, servicemanager_
     utils::StringFromCStr(pbInstanceStatus.run_state)       = aosInstanceStatus.mRunState.ToString();
 
     if (!aosInstanceStatus.mError.IsNone()) {
-        pbInstanceStatus.has_error_info = true;
-        pbInstanceStatus.error_info     = utils::ErrorToPB(aosInstanceStatus.mError);
+        pbInstanceStatus.has_error = true;
+        pbInstanceStatus.error     = utils::ErrorToPB(aosInstanceStatus.mError);
     }
 }
 

--- a/tests/smclient/src/main.cpp
+++ b/tests/smclient/src/main.cpp
@@ -193,13 +193,13 @@ void PBToInstanceStatus(const servicemanager_v4_InstanceStatus& pbInstance, Inst
     aosInstance.mServiceVersion = utils::StringFromCStr(pbInstance.service_version);
     utils::PBToEnum(pbInstance.run_state, aosInstance.mRunState);
 
-    aosInstance.mError = utils::PBToError(pbInstance.error_info);
+    aosInstance.mError = utils::PBToError(pbInstance.error);
 
-    if (pbInstance.has_error_info) {
-        if (pbInstance.error_info.exit_code) {
-            aosInstance.mError = pbInstance.error_info.exit_code;
+    if (pbInstance.has_error) {
+        if (pbInstance.error.exit_code) {
+            aosInstance.mError = pbInstance.error.exit_code;
         } else {
-            aosInstance.mError = static_cast<ErrorEnum>(pbInstance.error_info.aos_code);
+            aosInstance.mError = static_cast<ErrorEnum>(pbInstance.error.aos_code);
         }
     }
 }


### PR DESCRIPTION
This field was renamed in protocol. Update SM client accordingly.